### PR TITLE
Upgrading the Lambda function Runtime from Python2.7 to Python3.6.

### DIFF
--- a/amazon-ec2-global-dashboard.yaml
+++ b/amazon-ec2-global-dashboard.yaml
@@ -45,7 +45,7 @@ Resources:
             - '         Namespace=''Running-instances'''
             - '     )'
       Handler: index.lambda_handler
-      Runtime: python2.7
+      Runtime: python3.6
       Timeout: '30'
       Role: !GetAtt 
         - LambdaExecutionRole


### PR DESCRIPTION
Python 2.7 is now deprecated.
Please see more info on why we needed to upgrade to Python3 in the link below.
https://aws.amazon.com/blogs/compute/continued-support-for-python-2-7-on-aws-lambda/ 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.